### PR TITLE
Foxhound: remove native_ property from TaintOperation

### DIFF
--- a/dom/tainting/nsTaintingUtils.cpp
+++ b/dom/tainting/nsTaintingUtils.cpp
@@ -178,7 +178,6 @@ TaintLocation GetTaintLocation() {
 nsresult MarkTaintOperation(StringTaint& aTaint, const char* name) {
   JSContext *cx = nsContentUtils::GetCurrentJSContext();
   auto op = GetTaintOperation(cx, name);
-  op.setNative();
   aTaint.extend(op);
   return NS_OK;
 }
@@ -187,7 +186,6 @@ static nsresult MarkTaintOperation(JSContext *cx, nsACString &str, const char* n
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(cx, name);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -202,7 +200,6 @@ static nsresult MarkTaintOperation(JSContext *cx, nsAString &str, const char* na
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(cx, name);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -212,7 +209,6 @@ nsresult MarkTaintOperation(nsAString &str, const char* name, const nsINode* nod
 {
   if (str.isTainted()) {
     TaintOperation op = GetTaintOperation(nsContentUtils::GetCurrentJSContext(), name, node);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -227,7 +223,6 @@ static nsresult MarkTaintOperation(JSContext *cx, nsAString &str, const char* na
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(cx, name, args);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -242,7 +237,6 @@ static nsresult MarkTaintOperation(JSContext *cx, nsACString &str, const char* n
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(cx, name, args);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -257,7 +251,6 @@ static nsresult MarkTaintOperation(JSContext *cx, nsCString &str, const char* na
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(cx, name, args);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -272,7 +265,6 @@ nsresult MarkTaintOperation(nsACString &str, const char* name, const nsACString 
 {
   if (str.isTainted()) {
     auto op = GetTaintOperation(nsContentUtils::GetCurrentJSContext(), name, arg);
-    op.setNative();
     str.Taint().extend(op);
   }
   return NS_OK;
@@ -280,21 +272,18 @@ nsresult MarkTaintOperation(nsACString &str, const char* name, const nsACString 
 
 static nsresult MarkTaintSource(nsAString &str, TaintOperation operation) {
   operation.setSource();
-  operation.setNative();
   str.Taint().overlay(0, str.Length(), operation);
   return NS_OK;
 }
 
 static nsresult MarkTaintSource(nsACString &str, TaintOperation operation) {
   operation.setSource();
-  operation.setNative();
   str.Taint().overlay(0, str.Length(), operation);
   return NS_OK;
 }
 
 static nsresult MarkTaintSource(mozilla::dom::DOMString &str, TaintOperation operation) {
   operation.setSource();
-  operation.setNative();
   str.Taint().overlay(0, str.Length(), operation);
   return NS_OK;
 }
@@ -304,7 +293,6 @@ nsresult MarkTaintSource(JSContext* cx, JSString* str, const char* name)
   if (isSourceActive(name)) {
     TaintOperation op = GetTaintOperation(cx, name);
     op.setSource();
-    op.setNative();
     JS_MarkTaintSource(cx, str, op);
   }
   return NS_OK;
@@ -314,7 +302,6 @@ nsresult MarkTaintSource(JSContext* aCx, JSString* str, const char* name, const 
   if (isSourceActive(name)) {
     TaintOperation op = GetTaintOperation(aCx, name, arg);
     op.setSource();
-    op.setNative();
     JS_MarkTaintSource(aCx, str, op);
   }
   return NS_OK;
@@ -324,7 +311,6 @@ nsresult MarkTaintSource(JSContext* cx, JS::MutableHandle<JS::Value> aValue, con
   if (isSourceActive(name)) {
     TaintOperation op = GetTaintOperation(cx, name);
     op.setSource();
-    op.setNative();
     JS_MarkTaintSource(cx, aValue, op);
   }
   return NS_OK;
@@ -335,7 +321,6 @@ nsresult MarkTaintSource(JSContext* cx, JS::MutableHandle<JS::Value> aValue, con
   if (isSourceActive(name)) {
     TaintOperation op = GetTaintOperation(cx, name, arg);
     op.setSource();
-    op.setNative();
     JS_MarkTaintSource(cx, aValue, op);
   }
   return NS_OK;
@@ -367,7 +352,6 @@ nsresult MarkTaintSource(nsAString &str, const char* name, const nsAString &arg)
 
 static nsresult MarkTaintSource(TaintFlow &flow, TaintOperation operation) {
   operation.setSource();
-  operation.setNative();
   flow.extend(operation);
   return NS_OK;
 }

--- a/js/src/builtin/Array.cpp
+++ b/js/src/builtin/Array.cpp
@@ -1492,7 +1492,7 @@ bool js::array_join(JSContext* cx, unsigned argc, Value* vp) {
 
   if(str->isTainted()) {
     // Foxhound: add taint operation.
-    str->taint().extend(TaintOperationFromContext(cx, "Array.join", true, sepstr));
+    str->taint().extend(TaintOperationFromContext(cx, "Array.join", sepstr));
   }
 
   args.rval().setString(str);

--- a/js/src/builtin/JSON.cpp
+++ b/js/src/builtin/JSON.cpp
@@ -2153,7 +2153,7 @@ bool json_stringify(JSContext* cx, unsigned argc, Value* vp) {
     // Foxhound: Add stringify operation to taint flows.
     if (str->isTainted()) {
       str->taint().extend(
-          TaintOperationFromContext(cx, "JSON.stringify", true));
+          TaintOperationFromContext(cx, "JSON.stringify"));
     }
     args.rval().setString(str);
   } else {

--- a/js/src/builtin/RegExp.cpp
+++ b/js/src/builtin/RegExp.cpp
@@ -152,7 +152,7 @@ bool js::CreateRegExpMatchResult(JSContext* cx, HandleRegExpShared re,
       // array to avoid GC issues.
       if (str->taint().hasTaint()) {
         str->taint().extend(
-          TaintOperation("RegExp.prototype.exec", true, TaintLocationFromContext(cx),
+          TaintOperation("RegExp.prototype.exec", TaintLocationFromContext(cx),
                          { taintarg_jsstring_full(cx, srcStr), taintarg_jsstring(cx, str), taintarg(cx, i) }));
       }
       arr->setDenseInitializedLength(i + 1);

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -152,7 +152,7 @@ js::str_tainted(JSContext* cx, unsigned argc, Value* vp)
   }
   // We store the string as argument for a manual taint operation. This way it's easy to see what
   // the original value of a manually tainted string was for debugging/testing.
-  TaintOperation op = TaintOperation(source.c_str(), true, TaintLocationFromContext(cx), { taintarg(cx, str) });
+  TaintOperation op = TaintOperation(source.c_str(), TaintLocationFromContext(cx), { taintarg(cx, str) });
   op.setSource();
 
   JSString* tainted_str = NewDependentString(cx, str, 0, str->length());
@@ -202,12 +202,6 @@ str_taint_getter(JSContext* cx, unsigned argc, Value* vp)
         return false;
 
       if (!JS_DefineProperty(cx, node, "operation", operation, JSPROP_READONLY | JSPROP_ENUMERATE | JSPROP_PERMANENT))
-        return false;
-
-      RootedValue isBuiltIn(cx);
-      isBuiltIn.setBoolean(taint_node.operation().isNative());
-
-      if (!JS_DefineProperty(cx, node, "builtin", isBuiltIn, JSPROP_READONLY | JSPROP_ENUMERATE | JSPROP_PERMANENT))
         return false;
 
       RootedValue isSource(cx);
@@ -519,7 +513,7 @@ static bool str_escape(JSContext* cx, unsigned argc, Value* vp) {
 
   // Foxhound: set new taint
   if(newtaint.hasTaint()) {
-    newtaint.extend(TaintOperationFromContext(cx, "escape", true, str));
+    newtaint.extend(TaintOperationFromContext(cx, "escape", str));
     res->setTaint(cx, newtaint);
   }
 
@@ -679,7 +673,7 @@ static bool str_unescape(JSContext* cx, unsigned argc, Value* vp) {
 
   // Foxhound: add taint operation.
   if(newtaint.hasTaint()) {
-    newtaint.extend(TaintOperationFromContext(cx, "unescape", true, str));
+    newtaint.extend(TaintOperationFromContext(cx, "unescape", str));
   }
 
   // Step 6.
@@ -1186,7 +1180,7 @@ static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
   // Foxhound: cache the taint up here to prevent GC issues
   SafeStringTaint taint(str->taint());
   if (taint.hasTaint()) {
-    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
+    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", str));
   }
 
   const size_t length = str->length();
@@ -1429,7 +1423,7 @@ static bool str_toLocaleLowerCase(JSContext* cx, unsigned argc, Value* vp) {
     // Foxhound: propagate taint and add operation
     MOZ_ASSERT(result.isString());
     if(str->isTainted()) {
-      result.toString()->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "toLocaleLowerCase", true, str)));
+      result.toString()->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "toLocaleLowerCase", str)));
     }
 
     args.rval().set(result);
@@ -1600,7 +1594,7 @@ static JSLinearString* ToUpperCase(JSContext* cx, JSLinearString* str) {
   mozilla::MaybeOneOf<Latin1StringChars, TwoByteStringChars> newChars;
   SafeStringTaint taint(str->taint());
   if (taint.hasTaint()) {
-    taint.extend(TaintOperationFromContextJSString(cx, "toUpperCase", true, str));
+    taint.extend(TaintOperationFromContextJSString(cx, "toUpperCase", str));
   }
 
   const size_t length = str->length();
@@ -1840,7 +1834,7 @@ static bool str_toLocaleUpperCase(JSContext* cx, unsigned argc, Value* vp) {
     // Foxhound: propagate taint and add operation
     MOZ_ASSERT(result.isString());
     if(str->isTainted()) {
-      result.toString()->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "toLocaleUpperCase", true, str)));
+      result.toString()->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "toLocaleUpperCase", str)));
     }
 
     args.rval().set(result);
@@ -1978,7 +1972,7 @@ static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
   // Latin-1 strings are already in Normalization Form C.
   if (form == NormalizationForm::NFC && str->hasLatin1Chars()) {
     if (str->isTainted()) {
-      str->taint().extend(TaintOperationFromContext(cx, "normalize", true, str));
+      str->taint().extend(TaintOperationFromContext(cx, "normalize", str));
     }
     // Step 7.
     args.rval().setString(str);
@@ -2009,7 +2003,7 @@ static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
   // Return if the input string is already normalized.
   if (alreadyNormalized.unwrap() == AlreadyNormalized::Yes) {
     if (str->isTainted()) {
-      str->taint().extend(TaintOperationFromContext(cx, "normalize", true, str));
+      str->taint().extend(TaintOperationFromContext(cx, "normalize", str));
     }
     // Step 7.
     args.rval().setString(str);
@@ -2023,7 +2017,7 @@ static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
 
   // Foxhound: Add taint operation.
   if (str->isTainted()) {
-    ns->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "normalize", true, str)));
+    ns->setTaint(cx, str->taint().safeCopy().extend(TaintOperationFromContext(cx, "normalize", str)));
   }
 
   // Step 7.
@@ -2262,7 +2256,7 @@ static bool str_charAt(JSContext* cx, unsigned argc, Value* vp) {
   // Foxhound: avoid atoms here if the base string is tainted. TODO(samuel)
   if (str->isTainted() && index.isSome()) {
     str = NewDependentString(cx, str, index.value(), 1);
-    str->taint().extend(TaintOperation("charAt", true, TaintLocationFromContext(cx), { taintarg(cx, index.value()) }));
+    str->taint().extend(TaintOperation("charAt", TaintLocationFromContext(cx), { taintarg(cx, index.value()) }));
     args.rval().setString(str);
   } else { // Foxhound: only use static string if not tainted
     // Step 6.
@@ -3276,13 +3270,13 @@ static JSLinearString* TrimString(JSContext* cx, JSString* str, bool trimStart,
   if (result && result->isTainted()) {
     AutoCheckCannotGC nogc;
     if (trimStart && trimEnd) {
-      result->taint().extend(TaintOperationFromContext(cx, "trim", true));
+      result->taint().extend(TaintOperationFromContext(cx, "trim"));
     } else if (trimStart) {
-      result->taint().extend(TaintOperationFromContext(cx, "trimStart", true));
+      result->taint().extend(TaintOperationFromContext(cx, "trimStart"));
     } else if (trimEnd) {
-      result->taint().extend(TaintOperationFromContext(cx, "trimEnd", true));
+      result->taint().extend(TaintOperationFromContext(cx, "trimEnd"));
     } else {
-      result->taint().extend(TaintOperationFromContext(cx, "trim", true));
+      result->taint().extend(TaintOperationFromContext(cx, "trim"));
     }
   }
 
@@ -3936,7 +3930,7 @@ static JSString* ReplaceAll(JSContext* cx, JSLinearString* string,
   // Foxhound: extend the taint flow
   if(result.taint().hasTaint()) {
     result.taint().extend(
-      TaintOperationFromContextJSString(cx, "replaceAll", true, searchString, replaceString));
+      TaintOperationFromContextJSString(cx, "replaceAll", searchString, replaceString));
   }
 
   // Step 16.
@@ -4216,7 +4210,7 @@ static ArrayObject* SplitHelper(JSContext* cx, Handle<JSLinearString*> str,
 
     if(sub->isTainted()) {
       // Foxhound: extend taint flow
-      sub->taint().extend(TaintOperation("split", true, TaintLocationFromContext(cx),
+      sub->taint().extend(TaintOperation("split", TaintLocationFromContext(cx),
                                         { taintarg(cx, sep), taintarg(cx, count++) }));
     }
 
@@ -4243,7 +4237,7 @@ static ArrayObject* SplitHelper(JSContext* cx, Handle<JSLinearString*> str,
 
   // Foxhound: extend taint flow
   if(sub->isTainted()) {
-    sub->taint().extend(TaintOperation("split", true, TaintLocationFromContext(cx), { taintarg(cx, sep), taintarg(cx, count++) }));
+    sub->taint().extend(TaintOperation("split", TaintLocationFromContext(cx), { taintarg(cx, sep), taintarg(cx, count++) }));
   }
 
   // Step 18.
@@ -4285,7 +4279,7 @@ static ArrayObject* CharSplitHelper(JSContext* cx, Handle<JSLinearString*> str,
     }
     // Foxhound: extend taint flow
     if(sub->isTainted()) {
-      sub->taint().extend(TaintOperation("split", true, TaintLocationFromContext(cx), { taintarg(cx, u""), taintarg(cx, count++) }));
+      sub->taint().extend(TaintOperation("split", TaintLocationFromContext(cx), { taintarg(cx, u""), taintarg(cx, count++) }));
     }
 
     splits->initDenseElement(i, StringValue(sub));
@@ -4318,7 +4312,7 @@ static MOZ_ALWAYS_INLINE ArrayObject* SplitSingleCharHelper(
   }
   splits->ensureDenseInitializedLength(0, count + 1);
 
-  TaintOperation op = TaintOperationFromContext(cx, "split", true);
+  TaintOperation op = TaintOperationFromContext(cx, "split");
 
   // Add substrings.
   uint32_t splitsIndex = 0;
@@ -5139,9 +5133,9 @@ static MOZ_ALWAYS_INLINE bool Encode(JSContext* cx, Handle<JSLinearString*> str,
   SafeStringTaint taint(sb.empty() ? str->taint() : sb.taint());
   if(taint.hasTaint()) {
     if (unescapedSet == js_isUriReservedPlusPound) {
-      taint.extend(TaintOperationFromContext(cx, "encodeURI", true, str));
+      taint.extend(TaintOperationFromContext(cx, "encodeURI", str));
     } else {
-      taint.extend(TaintOperationFromContext(cx, "encodeURIComponent", true, str));
+      taint.extend(TaintOperationFromContext(cx, "encodeURIComponent", str));
     }
   }
 
@@ -5305,9 +5299,9 @@ static bool Decode(JSContext* cx, Handle<JSLinearString*> str,
   SafeStringTaint taint(sb.empty() ? str->taint() : sb.taint());
   if(taint.hasTaint()) {
     if(reservedSet == js_isUriReservedPlusPound) {
-      taint.extend(TaintOperationFromContext(cx, "decodeURI", true, str));
+      taint.extend(TaintOperationFromContext(cx, "decodeURI", str));
     } else {
-      taint.extend(TaintOperationFromContext(cx, "decodeURIComponent", true, str));
+      taint.extend(TaintOperationFromContext(cx, "decodeURIComponent", str));
     }
   }
 

--- a/js/src/jit/VMFunctions.cpp
+++ b/js/src/jit/VMFunctions.cpp
@@ -1360,7 +1360,7 @@ JSString* StringReplace(JSContext* cx, HandleString string,
   // Foxhound: We have to root the string here, as we introduce the TaintOperationFromContext call, which can trigger the GC.
   Rooted<JSString*> str(cx, str_replace_string_raw(cx, string, pattern, repl));
   if (str && str->taint().hasTaint()) {
-    str->taint().extend(TaintOperationFromContext(cx, "replace", true, pattern, repl));
+    str->taint().extend(TaintOperationFromContext(cx, "replace", pattern, repl));
   }
   return str;
 }

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -5040,19 +5040,19 @@ JS_MarkTaintSource(JSContext* cx, JS::MutableHandleValue value, const TaintOpera
 JS_PUBLIC_API TaintOperation
 JS_GetTaintOperation(JSContext* cx, const char* sink, JS::HandleValue arg)
 {
-  return TaintOperationFromContext(cx, sink, false, arg, false);
+  return TaintOperationFromContext(cx, sink, arg, false);
 }
 
 JS_PUBLIC_API TaintOperation
 JS_GetTaintOperationFullArgs(JSContext* cx, const char* sink, JS::HandleValue arg)
 {
-  return TaintOperationFromContext(cx, sink, false, arg, true);
+  return TaintOperationFromContext(cx, sink, arg, true);
 }
 
 JS_PUBLIC_API TaintOperation
 JS_GetTaintOperation(JSContext* cx, const char* sink)
 {
-  return TaintOperationFromContext(cx, sink, false);
+  return TaintOperationFromContext(cx, sink);
 }
 
 JS_PUBLIC_API TaintLocation
@@ -5115,7 +5115,7 @@ JS_ReportTaintSink(JSContext* cx, JS::HandleString str, const char* sink, JS::Ha
   JS_ReportWarningUTF8(cx, "Tainted flow from %s into %s!", firstRange.flow().source().name(), sink);
 
   // Extend the taint flow to include the sink function
-  str->taint().extend(TaintOperationFromContext(cx, sink, true, arg, true));
+  str->taint().extend(TaintOperationFromContext(cx, sink, arg, true));
 
   // Trigger a custom event that can be caught by an extension.
   // To simplify things, this part is implemented in JavaScript. Since we don't want to recompile

--- a/js/src/jstaint.cpp
+++ b/js/src/jstaint.cpp
@@ -290,52 +290,49 @@ TaintLocation JS::TaintLocationFromContext(JSContext* cx) {
 }
 
 TaintOperation JS::TaintOperationFromContext(JSContext* cx, const char* name,
-                                             bool native, JS::HandleValue args,
+                                             JS::HandleValue args,
                                              bool fullArgs) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs(cx, args, fullArgs));
 }
 
 TaintOperation JS::TaintOperationFromContext(JSContext* cx, const char* name,
-                                             bool native,
                                              JS::HandleString arg) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs(cx, arg));
 }
 
 TaintOperation JS::TaintOperationFromContext(JSContext* cx, const char* name,
-                                             bool native, JS::HandleString arg1,
+                                             JS::HandleString arg1,
                                              JS::HandleString arg2) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs(cx, arg1, arg2));
 }
 
 TaintOperation JS::TaintOperationFromContextJSString(JSContext* cx,
                                                      const char* name,
-                                                     bool native,
                                                      JSString* const& arg) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs_jsstring(cx, arg));
 }
 
 TaintOperation JS::TaintOperationFromContextJSString(JSContext* cx,
                                                      const char* name,
-                                                     bool native,
                                                      JSString* const& arg1,
                                                      JSString* const& arg2) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs_jsstring(cx, arg1, arg2));
 }
 
 TaintOperation JS::TaintOperationFromContextJSString(
-    JSContext* cx, const char* name, bool native,
+    JSContext* cx, const char* name,
     const JSLinearString* const& arg1, const JSLinearString* const& arg2) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx),
+  return TaintOperation(name, TaintLocationFromContext(cx),
                         taintargs_jsstring(cx, arg1, arg2));
 }
 
 TaintOperation JS::TaintOperationConcat(JSContext* cx, const char* name,
-                                        bool native, JS::HandleString arg1,
+                                        JS::HandleString arg1,
                                         JS::HandleString arg2) {
   std::vector<std::u16string> args = taintargs(cx, arg1, arg2);
   std::u16string whichStringsAreTainted = u"tainted:";
@@ -346,11 +343,11 @@ TaintOperation JS::TaintOperationConcat(JSContext* cx, const char* name,
     whichStringsAreTainted.append(u"R");
   }
   args.push_back(whichStringsAreTainted);
-  return TaintOperation(name, native, TaintLocationFromContext(cx), args);
+  return TaintOperation(name, TaintLocationFromContext(cx), args);
 }
 
 TaintOperation JS::TaintOperationConcat(JSContext* cx, const char* name,
-                                        bool native, JSString* const& arg1,
+                                        JSString* const& arg1,
                                         JSString* const& arg2) {
   std::vector<std::u16string> args = taintargs_jsstring(cx, arg1, arg2);
   std::u16string whichStringsAreTainted = u"tainted:";
@@ -361,12 +358,11 @@ TaintOperation JS::TaintOperationConcat(JSContext* cx, const char* name,
     whichStringsAreTainted.append(u"R");
   }
   args.push_back(whichStringsAreTainted);
-  return TaintOperation(name, native, TaintLocationFromContext(cx), args);
+  return TaintOperation(name, TaintLocationFromContext(cx), args);
 }
 
-TaintOperation JS::TaintOperationFromContext(JSContext* cx, const char* name,
-                                             bool native) {
-  return TaintOperation(name, native, TaintLocationFromContext(cx));
+TaintOperation JS::TaintOperationFromContext(JSContext* cx, const char* name) {
+  return TaintOperation(name, TaintLocationFromContext(cx));
 }
 
 void JS::MarkTaintedFunctionArguments(JSContext* cx, JSFunction* function,
@@ -569,7 +565,6 @@ void JS::PrintJsonTaint(JSContext* cx, JSString* str, HandleValue location,
       const TaintOperation& op = node.operation();
       json.beginObject();
       json.property("operation", op.name());
-      json.boolProperty("builtin", op.isNative());
       json.boolProperty("source", op.isSource());
 
       const TaintLocation& loc = op.location();

--- a/js/src/jstaint.h
+++ b/js/src/jstaint.h
@@ -76,39 +76,38 @@ std::string convertDigestToHexString(const TaintMd5& digest);
 TaintLocation TaintLocationFromContext(JSContext* cx);
 
 TaintOperation TaintOperationFromContext(JSContext* cx, const char* name,
-                                         bool native, JS::HandleValue args,
+                                         JS::HandleValue args,
                                          bool fullArgs = false);
 
 TaintOperation TaintOperationFromContext(JSContext* cx, const char* name,
-                                         bool native, JS::HandleString arg);
+                                         JS::HandleString arg);
 
 TaintOperation TaintOperationFromContext(JSContext* cx, const char* name,
-                                         bool native, JS::HandleString arg1,
+                                         JS::HandleString arg1,
                                          JS::HandleString arg2);
 
 TaintOperation TaintOperationFromContextJSString(JSContext* cx,
-                                                 const char* name, bool native,
+                                                 const char* name,
                                                  JSString* const& str);
 
 TaintOperation TaintOperationFromContextJSString(JSContext* cx,
-                                                 const char* name, bool native,
+                                                 const char* name,
                                                  JSString* const& str1,
                                                  JSString* const& str2);
 
 TaintOperation TaintOperationFromContextJSString(
-    JSContext* cx, const char* name, bool native,
+    JSContext* cx, const char* name,
     const JSLinearString* const& str1, const JSLinearString* const& str2);
 
 TaintOperation TaintOperationConcat(JSContext* cx, const char* name,
-                                    bool native, JS::HandleString str1,
+                                    JS::HandleString str1,
                                     JS::HandleString str2);
 
 TaintOperation TaintOperationConcat(JSContext* cx, const char* name,
-                                    bool native, JSString* const& str1,
+                                    JSString* const& str1,
                                     JSString* const& str2);
 
-TaintOperation TaintOperationFromContext(JSContext* cx, const char* name,
-                                         bool native);
+TaintOperation TaintOperationFromContext(JSContext* cx, const char* name);
 
 // Mark all tainted arguments of a function call.
 // This is mainly useful for tracing tainted arguments through the code.

--- a/js/src/vm/JSONParser.cpp
+++ b/js/src/vm/JSONParser.cpp
@@ -852,7 +852,7 @@ inline bool JSONFullParseHandler<CharT>::setStringValue(
   if (ST != JSONStringType::PropertyName && taint.hasTaint()) {
     JSString* path = parser->CurrentJsonPath();
     RootedString jsonPath(cx, path);
-    op = TaintOperationFromContextJSString(cx, "JSON.parse", true, jsonPath);
+    op = TaintOperationFromContextJSString(cx, "JSON.parse", jsonPath);
   }
   
   JSString* str;
@@ -886,7 +886,7 @@ inline bool JSONFullParseHandler<CharT>::setStringValue(
   if (ST != JSONStringType::PropertyName && builder.buffer.taint()) {
     JSString* path = parser->CurrentJsonPath();
     RootedString jsonPath(cx, path);
-    op = TaintOperationFromContextJSString(cx, "JSON.parse", true, jsonPath);
+    op = TaintOperationFromContextJSString(cx, "JSON.parse", jsonPath);
   }
 
   JSString* str;

--- a/js/src/vm/SelfHosting.cpp
+++ b/js/src/vm/SelfHosting.cpp
@@ -1682,7 +1682,7 @@ taint_addTaintOperation_native_full(JSContext* cx, unsigned argc, Value* vp)
         }
     }
 
-    str->taint().extend(TaintOperation(op_chars.get(), true, TaintLocationFromContext(cx), taint_args));
+    str->taint().extend(TaintOperation(op_chars.get(), TaintLocationFromContext(cx), taint_args));
 
     return true;
 }
@@ -1732,7 +1732,7 @@ taint_addTaintOperation_native(JSContext* cx, unsigned argc, Value* vp)
         }
     }
 
-    str->taint().extend(TaintOperation(op_chars.get(), true, TaintLocationFromContext(cx), taint_args));
+    str->taint().extend(TaintOperation(op_chars.get(), TaintLocationFromContext(cx), taint_args));
 
     return true;
 }

--- a/js/src/vm/StringType.cpp
+++ b/js/src/vm/StringType.cpp
@@ -1391,7 +1391,7 @@ JSString* js::ConcatStrings(
 
   TaintOperation op("concat");
   if ((left && right) && (left->taint().hasTaint() || right->taint().hasTaint())) {
-    op = JS::TaintOperationConcat(cx, "concat", true, left, right);
+    op = JS::TaintOperationConcat(cx, "concat", left, right);
   }
   
   JSString* str = ConcatStringsQuiet<allowGC>(cx, left, right, heap);

--- a/taint/Taint.cpp
+++ b/taint/Taint.cpp
@@ -85,16 +85,6 @@ TaintOperation::TaintOperation(const char* name, TaintLocation location,
     : name_(name),
       arguments_(args),
       source_(false),
-      native_(false),
-      location_(std::move(location)) {}
-
-TaintOperation::TaintOperation(const char* name, bool native,
-                               TaintLocation location,
-                               std::initializer_list<std::u16string> args)
-    : name_(name),
-      arguments_(args),
-      source_(false),
-      native_(native),
       location_(std::move(location)) {}
 
 TaintOperation::TaintOperation(const char* name, TaintLocation location,
@@ -102,71 +92,36 @@ TaintOperation::TaintOperation(const char* name, TaintLocation location,
     : name_(name),
       arguments_(std::move(args)),
       source_(false),
-      native_(false),
-      location_(std::move(location)) {}
-
-TaintOperation::TaintOperation(const char* name, bool native,
-                               TaintLocation location,
-                               std::vector<std::u16string> args)
-    : name_(name),
-      arguments_(std::move(args)),
-      source_(false),
-      native_(native),
       location_(std::move(location)) {}
 
 TaintOperation::TaintOperation(const char* name,
                                std::initializer_list<std::u16string> args)
-    : name_(name), arguments_(args), source_(false), native_(false) {}
-
-TaintOperation::TaintOperation(const char* name, bool native,
-                               std::initializer_list<std::u16string> args)
-    : name_(name), arguments_(args), source_(false), native_(native) {}
+    : name_(name), arguments_(args), source_(false) {}
 
 TaintOperation::TaintOperation(const char* name,
                                std::vector<std::u16string> args)
     : name_(name),
       arguments_(std::move(args)),
-      source_(false),
-      native_(false) {}
-
-TaintOperation::TaintOperation(const char* name, bool native,
-                               std::vector<std::u16string> args)
-    : name_(name),
-      arguments_(std::move(args)),
-      source_(false),
-      native_(native) {}
+      source_(false) {}
 
 TaintOperation::TaintOperation(const char* name)
-    : name_(name), source_(false), native_(false) {}
-
-TaintOperation::TaintOperation(const char* name, bool native)
-    : name_(name), source_(false), native_(native) {}
+    : name_(name), source_(false) {}
 
 TaintOperation::TaintOperation(const char* name, TaintLocation location)
     : name_(name),
       source_(false),
-      native_(false),
-      location_(std::move(location)) {}
-
-TaintOperation::TaintOperation(const char* name, bool native,
-                               TaintLocation location)
-    : name_(name),
-      source_(false),
-      native_(native),
       location_(std::move(location)) {}
 
 TaintOperation::TaintOperation(TaintOperation&& other) noexcept
     : name_(std::move(other.name_)),
       arguments_(std::move(other.arguments_)),
       source_(other.source_),
-      native_(other.native_),
       location_(std::move(other.location_)) {}
 
 TaintOperation& TaintOperation::operator=(TaintOperation&& other) noexcept {
   name_ = std::move(other.name_);
   arguments_ = std::move(other.arguments_);
   source_ = other.source_;
-  native_ = other.native_;
   location_ = std::move(other.location_);
   return *this;
 }
@@ -186,8 +141,7 @@ void TaintOperation::dump(const TaintOperation& op) {
   std::cout << "************************************************" << std::endl;
   std::cout << "Location: " << convert.to_bytes(op.location().filename()) << ":"
             << op.location().line() << ":" << op.location().pos() << std::endl;
-  std::cout << "Function: " << convert.to_bytes(op.location().function())
-            << " native[" << op.isNative() << "]" << std::endl;
+  std::cout << "Function: " << convert.to_bytes(op.location().function()) << std::endl;
   std::cout << "Args:" << std::endl;
   for (const auto& arg : op.arguments()) {
     len += arg.length();
@@ -1268,9 +1222,6 @@ TaintOperation LoadTaintOperationFromJSON(const json& aData) {
   if (aData[3].get<bool>()) {
     op.setSource();
   }
-  if (aData[4].get<bool>()) {
-    op.setNative();
-  }
   return op;
 }
 
@@ -1280,7 +1231,6 @@ json DumpTaintOperationAsJSON(const TaintOperation& aOperation) {
       DumpTaintLocationAsJSON(aOperation.location()),
       aOperation.arguments(),
       aOperation.isSource(),
-      aOperation.isNative(),
   });
 }
 

--- a/taint/Taint.h
+++ b/taint/Taint.h
@@ -122,30 +122,20 @@ class TaintLocation {
 class TaintOperation {
  public:
   TaintOperation(const char* name, std::initializer_list<std::u16string> args);
-  TaintOperation(const char* name, bool native,
-                 std::initializer_list<std::u16string> args);
 
   TaintOperation(const char* name, std::vector<std::u16string> args);
-  TaintOperation(const char* name, bool native,
-                 std::vector<std::u16string> args);
 
   TaintOperation(const char* name, TaintLocation location,
                  std::initializer_list<std::u16string> args);
-  TaintOperation(const char* name, bool native, TaintLocation location,
-                 std::initializer_list<std::u16string> args);
 
   TaintOperation(const char* name, TaintLocation location,
-                 std::vector<std::u16string> args);
-  TaintOperation(const char* name, bool native, TaintLocation location,
                  std::vector<std::u16string> args);
 
   // Constructs a taint operation with no arguments.
   explicit TaintOperation(const char* name);
-  TaintOperation(const char* name, bool native);
 
   // Constructs a taint operation with location information
   TaintOperation(const char* name, TaintLocation location);
-  TaintOperation(const char* name, bool native, TaintLocation location);
 
   // These work fine as long as we are using stl classes.
   TaintOperation(const TaintOperation& other) = default;
@@ -162,8 +152,6 @@ class TaintOperation {
   // Getter and setter to mark a taint source
   bool isSource() const { return source_; }
   void setSource() { source_ = true; }
-  bool isNative() const { return native_; }
-  void setNative() { native_ = true; }
 
   static void dump(const TaintOperation& op);
 
@@ -177,9 +165,6 @@ class TaintOperation {
 
   // Is this Operation a Source
   bool source_;
-
-  // Is this function an internal function?
-  bool native_;
 
   TaintLocation location_;
 };

--- a/xpcom/string/nsReadableUtils.cpp
+++ b/xpcom/string/nsReadableUtils.cpp
@@ -241,7 +241,7 @@ void ToUpperCase(const nsACString& aSource, nsACString& aDest) {
 
   // Foxhound: propagate taint into aDest.
   aDest.AssignTaint(aSource.Taint());
-  aDest.Taint().extend(TaintOperation("ToUpperCase", true));
+  aDest.Taint().extend(TaintOperation("ToUpperCase"));
 }
 
 void ToLowerCase(nsACString& aCString) {
@@ -274,7 +274,7 @@ void ToLowerCase(const nsACString& aSource, nsACString& aDest) {
 
   // Foxhound: propagate taint into aDest.
   aDest.AssignTaint(aSource.Taint());
-  aDest.Taint().extend(TaintOperation("ToLowerCase", true));
+  aDest.Taint().extend(TaintOperation("ToLowerCase"));
 }
 
 void ParseString(const nsACString& aSource, char aDelimiter,


### PR DESCRIPTION
The native_ flag (and associated isNative()/setNative() API) was used to distinguish built-in JS functions from user-defined ones, but this distinction is not needed for taint tracking. Remove the flag, all constructor overloads that accepted it, and the 'builtin' property it exposed to JavaScript.