### PR TITLE
Fix #361

### DIFF
--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -1268,12 +1268,14 @@ static JSLinearString* ToLowerCaseInternal(JSContext* cx, JSLinearString* str) {
 template <typename CharT>
 static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
   JSLinearString* res = ToLowerCaseInternal<CharT>(cx, str);
-  if (res == str) {
-    res = NewDependentString(cx, str, 0, str->length());
+  if (res && str->isTainted()) {
+    if (res == str) {
+      res = NewDependentString(cx, str, 0, str->length());
+    }
+    SafeStringTaint taint(str->taint());
+    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
+    res->setTaint(taint);
   }
-  SafeStringTaint taint(str->taint());
-  taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
-  res->setTaint(taint);
   return res;
 }
 

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -1271,6 +1271,9 @@ static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
   if (res && str->isTainted()) {
     if (res == str) {
       res = NewDependentString(cx, str, 0, str->length());
+      if (!res) {
+        return nullptr;
+      }
     }
     SafeStringTaint taint(str->taint());
     taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
@@ -1934,13 +1937,19 @@ static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
   CallArgs args = CallArgsFromVp(argc, vp);
   
   // Steps 1-2.
-  RootedString arg(cx,
+  RootedString str(cx,
                    ToStringForStringFunction(cx, "normalize", args.thisv()));
-  if (!arg) {
+  if (!str) {
     return false;
   }
 
-  auto* str = NewDependentString(cx, arg, 0, arg->length());
+  if (str->isTainted()) {
+    JSString* dep = NewDependentString(cx, str, 0, str->length());
+    if (!dep) {
+      return false;
+    }
+    str = dep;
+  }
 
   using NormalizationForm = mozilla::intl::String::NormalizationForm;
 

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -1276,7 +1276,7 @@ static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
       }
     }
     SafeStringTaint taint(str->taint());
-    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
+    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", str));
     res->setTaint(taint);
   }
   return res;
@@ -1935,7 +1935,7 @@ static bool str_localeCompare(JSContext* cx, unsigned argc, Value* vp) {
 static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
   AutoJSMethodProfilerEntry pseudoFrame(cx, "String.prototype", "normalize");
   CallArgs args = CallArgsFromVp(argc, vp);
-  
+
   // Steps 1-2.
   RootedString str(cx,
                    ToStringForStringFunction(cx, "normalize", args.thisv()));

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -1172,16 +1172,11 @@ static size_t ToLowerCaseLength(const char16_t* chars, size_t startIndex,
 }
 
 template <typename CharT>
-static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
+static JSLinearString* ToLowerCaseInternal(JSContext* cx, JSLinearString* str) {
   // Unlike toUpperCase, toLowerCase has the nice invariant that if the
   // input is a Latin-1 string, the output is also a Latin-1 string.
 
   StringChars<CharT> newChars(cx);
-  // Foxhound: cache the taint up here to prevent GC issues
-  SafeStringTaint taint(str->taint());
-  if (taint.hasTaint()) {
-    taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", str));
-  }
 
   const size_t length = str->length();
   size_t resultLength;
@@ -1234,11 +1229,7 @@ static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
     }
 
     // If no character needs to change, return the input string.
-    // Foxhound: disabled. We need to return a new string here (so we can correctly
-    // set the taint). However, we are in an AutoCheckCannotGC block, so cannot
-    // allocate a new string here.
     if (i == length) {
-      str->setTaint(cx, taint);
       return str;
     }
 
@@ -1269,12 +1260,20 @@ static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
     }
   }
 
-  // Foxhound: Add taint operation to all taint ranges of the input string.
   JSLinearString* res = newChars.template toStringDontDeflate<CanGC>(cx, resultLength);
-  if (res && taint.hasTaint()) {
-    res->setTaint(cx, taint);
-  }
 
+  return res;
+}
+
+template <typename CharT>
+static JSLinearString* ToLowerCase(JSContext* cx, JSLinearString* str) {
+  JSLinearString* res = ToLowerCaseInternal<CharT>(cx, str);
+  if (res == str) {
+    res = NewDependentString(cx, str, 0, str->length());
+  }
+  SafeStringTaint taint(str->taint());
+  taint.extend(TaintOperationFromContextJSString(cx, "toLowerCase", true, str));
+  res->setTaint(taint);
   return res;
 }
 
@@ -1931,13 +1930,15 @@ static bool str_localeCompare(JSContext* cx, unsigned argc, Value* vp) {
 static bool str_normalize(JSContext* cx, unsigned argc, Value* vp) {
   AutoJSMethodProfilerEntry pseudoFrame(cx, "String.prototype", "normalize");
   CallArgs args = CallArgsFromVp(argc, vp);
-
+  
   // Steps 1-2.
-  RootedString str(cx,
+  RootedString arg(cx,
                    ToStringForStringFunction(cx, "normalize", args.thisv()));
-  if (!str) {
+  if (!arg) {
     return false;
   }
+
+  auto* str = NewDependentString(cx, arg, 0, arg->length());
 
   using NormalizationForm = mozilla::intl::String::NormalizationForm;
 

--- a/taint/test/mochitest/mochitest.ini
+++ b/taint/test/mochitest/mochitest.ini
@@ -61,3 +61,5 @@ scheme = https
 [test_network_request_url_argument.html]
 [test_string_iterator.html]
 [test_json_stringify.html]
+[test_toLowerCase.html]
+[test_normalize.html]

--- a/taint/test/mochitest/test_normalize.html
+++ b/taint/test/mochitest/test_normalize.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Test normalize (see
+      https://github.com/SAP/project-foxhound/issues/361)
+    </title>
+    <script src="/tests/SimpleTest/SimpleTest.js"></script>
+    <link rel="stylesheet" href="/tests/SimpleTest/test.css" />
+
+    <script type="text/javascript">
+      function test(str) {
+        const s = String.tainted(str);
+        const t = s.normalize();
+        SimpleTest.is(s.taint[0].flow.length, 1);
+        SimpleTest.is(t.taint[0].flow.length, 2);
+      }
+
+      add_task(async function test_normalize() {
+        test("hello");
+        test("\u0041\u006d\u00e9\u006c\u0069\u0065");
+      });
+    </script>
+  </head>
+
+  <body></body>
+</html>

--- a/taint/test/mochitest/test_toLowerCase.html
+++ b/taint/test/mochitest/test_toLowerCase.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Test toLowerCase (see
+      https://github.com/SAP/project-foxhound/issues/361)
+    </title>
+    <script src="/tests/SimpleTest/SimpleTest.js"></script>
+    <link rel="stylesheet" href="/tests/SimpleTest/test.css" />
+
+    <script type="text/javascript">
+      function test(str) {
+        const s = String.tainted(str);
+        const t = s.toLowerCase();
+        SimpleTest.is(s.taint[0].flow.length, 1);
+        SimpleTest.is(t.taint[0].flow.length, 2);
+      }
+
+      add_task(async function test_toLowerCase() {
+        test("hello");
+        test("HELLO");
+      });
+    </script>
+  </head>
+
+  <body></body>
+</html>


### PR DESCRIPTION
We added mochitests for the two involved methods, i.e., toLowerCase and normalize. As a proposed solution, we create a NewDependentString when required.