### PR TITLE
Foxhound: Add taint propagation for HashChangeEvent.oldURL and newURL

### DIFF
--- a/dom/base/nsGlobalWindowInner.cpp
+++ b/dom/base/nsGlobalWindowInner.cpp
@@ -4511,6 +4511,10 @@ nsresult nsGlobalWindowInner::FireHashchange(const nsAString& aOldURL,
   init.mNewURL = aNewURL;
   init.mOldURL = aOldURL;
 
+  // Foxhound: Mark oldURL and newURL as taint sources for HashChangeEvent
+  MarkTaintSource(init.mOldURL, "HashChangeEvent.oldURL");
+  MarkTaintSource(init.mNewURL, "HashChangeEvent.newURL");
+
   RefPtr<HashChangeEvent> event =
       HashChangeEvent::Constructor(this, u"hashchange"_ns, init);
 


### PR DESCRIPTION
Fixes #323

When a hashchange event fires, the oldURL and newURL properties on the 
HashChangeEvent were not being marked as taint sources. This means that 
if tainted data (e.g. from location.hash or location.href) triggered a 
hash change, Foxhound would lose track of the taint flow through those 
event properties.

This fix adds MarkTaintSource calls for both init.mOldURL and init.mNewURL 
in FireHashchange() in nsGlobalWindowInner.cpp, following the same pattern 
used for location.hash and other existing taint sources.

Note: A mochitest is still needed to verify the fix. Opening as draft for 
early feedback.

Signed-off-by: Soliman Touelh <stouelh@umich.edu>