### PR TITLE
Foxhound: String.tainted() stores arbitrary extra params as source arguments

### DIFF
--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -152,7 +152,16 @@ js::str_tainted(JSContext* cx, unsigned argc, Value* vp)
   }
   // We store the string as argument for a manual taint operation. This way it's easy to see what
   // the original value of a manually tainted string was for debugging/testing.
-  TaintOperation op = TaintOperation(source.c_str(), TaintLocationFromContext(cx), { taintarg(cx, str) });
+  // Every parameter passed after the source name is additionally stored as a string in the
+  // arguments vector, allowing arbitrary custom source attributes to be attached to the operation.
+  std::vector<std::u16string> arguments;
+  arguments.push_back(taintarg(cx, str));
+  for (unsigned i = 2; i < args.length(); i++) {
+    RootedValue arg(cx, args[i]);
+    arguments.push_back(taintarg(cx, arg));
+  }
+
+  TaintOperation op = TaintOperation(source.c_str(), TaintLocationFromContext(cx), std::move(arguments));
   op.setSource();
 
   JSString* tainted_str = NewDependentString(cx, str, 0, str->length());

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -158,7 +158,7 @@ js::str_tainted(JSContext* cx, unsigned argc, Value* vp)
   arguments.push_back(taintarg(cx, str));
   for (unsigned i = 2; i < args.length(); i++) {
     RootedValue arg(cx, args[i]);
-    arguments.push_back(taintarg(cx, arg));
+    arguments.push_back(taintarg(cx, arg, true));
   }
 
   TaintOperation op = TaintOperation(source.c_str(), TaintLocationFromContext(cx), std::move(arguments));

--- a/taint/test/mochitest/mochitest.ini
+++ b/taint/test/mochitest/mochitest.ini
@@ -63,3 +63,4 @@ scheme = https
 [test_json_stringify.html]
 [test_toLowerCase.html]
 [test_normalize.html]
+[test_taint_source_arguments.html]

--- a/taint/test/mochitest/test_taint_source_arguments.html
+++ b/taint/test/mochitest/test_taint_source_arguments.html
@@ -86,6 +86,16 @@
         SimpleTest.is(op.operation, "manual taint source");
         checkArguments(op, ["hello", "attr1", "attr2"]);
       });
+
+      // very long arg
+      add_task(async function test_default_name_with_extra_args() {
+        let arg = "hello" + " hello".repeat(128);
+        const op = sourceOp(
+          String.tainted("hello", "foo", arg)
+        );
+        SimpleTest.is(op.operation, "foo");
+        checkArguments(op, ["hello", arg]);
+      });
     </script>
   </head>
 

--- a/taint/test/mochitest/test_taint_source_arguments.html
+++ b/taint/test/mochitest/test_taint_source_arguments.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Check that String.tainted() stores an arbitrary number of extra
+      parameters as strings in the taint operation arguments vector
+    </title>
+    <script src="/tests/SimpleTest/SimpleTest.js"></script>
+    <link rel="stylesheet" href="/tests/SimpleTest/test.css" />
+
+    <script type="text/javascript">
+      // Returns the taint source operation of a freshly tainted string.
+      // For a value produced by String.tainted() the flow consists of a
+      // single node, the manual taint source itself.
+      function sourceOp(value) {
+        check_tainted(value);
+        const op = value.taint[0].flow.find((o) => o.source);
+        SimpleTest.ok(op, "Tainted value must have a source operation");
+        return op;
+      }
+
+      function checkArguments(op, expected) {
+        // .arguments is exposed as a dense JS array by str_taint_getter.
+        SimpleTest.is(
+          op.arguments.length,
+          expected.length,
+          `Unexpected number of arguments: [${op.arguments}]`
+        );
+        for (let i = 0; i < expected.length; i++) {
+          SimpleTest.is(
+            op.arguments[i],
+            expected[i],
+            `Unexpected value for argument ${i}`
+          );
+        }
+      }
+
+      // Without a source name the operation keeps its default name and the
+      // arguments vector holds only the original string value.
+      add_task(async function test_no_extra_args() {
+        const op = sourceOp(String.tainted("hello"));
+        SimpleTest.is(op.operation, "manual taint source");
+        checkArguments(op, ["hello"]);
+      });
+
+      // A custom source name is stored as the operation name, not as an
+      // argument, so the arguments vector is unchanged.
+      add_task(async function test_source_name_only() {
+        const op = sourceOp(String.tainted("hello", "mysource"));
+        SimpleTest.is(op.operation, "mysource");
+        checkArguments(op, ["hello"]);
+      });
+
+      // Every parameter after the source name is appended to the arguments
+      // vector as a string.
+      add_task(async function test_single_extra_arg() {
+        const op = sourceOp(String.tainted("hello", "mysource", "attr1"));
+        SimpleTest.is(op.operation, "mysource");
+        checkArguments(op, ["hello", "attr1"]);
+      });
+
+      add_task(async function test_multiple_extra_args() {
+        const op = sourceOp(
+          String.tainted("hello", "mysource", "a", "b", "c")
+        );
+        SimpleTest.is(op.operation, "mysource");
+        checkArguments(op, ["hello", "a", "b", "c"]);
+      });
+
+      // Non-string parameters are coerced to strings before being stored.
+      add_task(async function test_non_string_extra_args() {
+        const op = sourceOp(
+          String.tainted("hello", "mysource", 42, true, null)
+        );
+        SimpleTest.is(op.operation, "mysource");
+        checkArguments(op, ["hello", "42", "true", "null"]);
+      });
+
+      // The default source name is used when the source name is undefined,
+      // while later parameters are still recorded as arguments.
+      add_task(async function test_default_name_with_extra_args() {
+        const op = sourceOp(
+          String.tainted("hello", undefined, "attr1", "attr2")
+        );
+        SimpleTest.is(op.operation, "manual taint source");
+        checkArguments(op, ["hello", "attr1", "attr2"]);
+      });
+    </script>
+  </head>
+
+  <body></body>
+</html>


### PR DESCRIPTION
Extend String.tainted() so that every parameter passed after the custom source name is coerced to a string and appended to the taint operation's arguments vector. args[0] is still the string to taint and args[1] the optional source name; args[2..] now become custom source attributes that surface via str.taint[i].flow[j].arguments.

Added a mochitest covering no extra args, source-name-only, single/multiple extra args, non-string coercion, and default-name-with-args.