### PR TITLE
Also store the full tainted string for String.tainted()

### DIFF
--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -155,7 +155,7 @@ js::str_tainted(JSContext* cx, unsigned argc, Value* vp)
   // Every parameter passed after the source name is additionally stored as a string in the
   // arguments vector, allowing arbitrary custom source attributes to be attached to the operation.
   std::vector<std::u16string> arguments;
-  arguments.push_back(taintarg(cx, str));
+  arguments.push_back(taintarg_full(cx, str));
   for (unsigned i = 2; i < args.length(); i++) {
     RootedValue arg(cx, args[i]);
     arguments.push_back(taintarg(cx, arg, true));

--- a/taint/test/mochitest/test_taint_source_arguments.html
+++ b/taint/test/mochitest/test_taint_source_arguments.html
@@ -96,6 +96,16 @@
         SimpleTest.is(op.operation, "foo");
         checkArguments(op, ["hello", arg]);
       });
+
+      // very long string
+      add_task(async function test_default_name_with_extra_args() {
+        let str = "hello" + " hello".repeat(128);
+        const op = sourceOp(
+          String.tainted(str, "foo", "bar")
+        );
+        SimpleTest.is(op.operation, "foo");
+        checkArguments(op, [str, "bar"]);
+      });
     </script>
   </head>
 


### PR DESCRIPTION
Builds on #377, stored the tainted string itself in full.