### PR TITLE
Foxhound: propagate taint through Trusted Types and expose a .taint property

### DIFF
--- a/dom/bindings/DOMString.h
+++ b/dom/bindings/DOMString.h
@@ -166,6 +166,16 @@ class MOZ_STACK_CLASS DOMString {
     } else if (!aString.IsEmpty()) {
       if (mozilla::StringBuffer* buf = aString.GetStringBuffer()) {
         SetKnownLiveStringBuffer(buf, aString.Length());
+        // Foxhound: SetKnownLiveStringBuffer copies the taint from the shared
+        // string buffer, but a string's taint frequently lives on the string
+        // object itself rather than the buffer (e.g. anything set via
+        // AssignTaint, which is how taint crosses from JS into an nsString).
+        // The UnownedStringBuffer state exposes `mTaint` (not the buffer's
+        // taint) to JS, so prefer the source string's own taint when present to
+        // avoid silently dropping it on the way back out.
+        if (aString.isTainted()) {
+          mTaint = aString.Taint();
+        }
       } else if (aString.IsLiteral()) {
         SetLiteralInternal(aString.BeginReading(), aString.Length());
         mTaint = aString.Taint();

--- a/dom/security/trusted-types/TrustedHTML.cpp
+++ b/dom/security/trusted-types/TrustedHTML.cpp
@@ -6,6 +6,9 @@
 
 #include "mozilla/dom/TrustedHTML.h"
 
+#include "mozilla/ErrorResult.h"
+#include "jsapi.h"
+
 namespace mozilla::dom {
 
 IMPL_TRUSTED_TYPE_CLASS(TrustedHTML)

--- a/dom/security/trusted-types/TrustedScript.cpp
+++ b/dom/security/trusted-types/TrustedScript.cpp
@@ -6,6 +6,9 @@
 
 #include "mozilla/dom/TrustedScript.h"
 
+#include "mozilla/ErrorResult.h"
+#include "jsapi.h"
+
 namespace mozilla::dom {
 
 IMPL_TRUSTED_TYPE_CLASS(TrustedScript)

--- a/dom/security/trusted-types/TrustedScriptURL.cpp
+++ b/dom/security/trusted-types/TrustedScriptURL.cpp
@@ -6,6 +6,9 @@
 
 #include "mozilla/dom/TrustedScriptURL.h"
 
+#include "mozilla/ErrorResult.h"
+#include "jsapi.h"
+
 namespace mozilla::dom {
 
 // https://w3c.github.io/trusted-types/dist/spec/#trused-script-url

--- a/dom/security/trusted-types/TrustedTypePolicy.cpp
+++ b/dom/security/trusted-types/TrustedTypePolicy.cpp
@@ -9,10 +9,26 @@
 #include "mozilla/dom/DOMString.h"
 #include "mozilla/dom/TrustedTypePolicyFactory.h"
 #include "mozilla/dom/TrustedTypesBinding.h"
+#include "nsTaintingUtils.h"
 
+#include <type_traits>
 #include <utility>
 
 namespace mozilla::dom {
+
+// Foxhound: name recorded in the taint flow when a value passes through a
+// trusted type.
+template <typename T>
+static const char* TrustedTypeName() {
+  if constexpr (std::is_same_v<T, TrustedHTML>) {
+    return "TrustedHTML";
+  } else if constexpr (std::is_same_v<T, TrustedScript>) {
+    return "TrustedScript";
+  } else {
+    static_assert(std::is_same_v<T, TrustedScriptURL>);
+    return "TrustedScriptURL";
+  }
+}
 
 NS_IMPL_CYCLE_COLLECTION_WRAPPERCACHE(TrustedTypePolicy, mParentObject,
                                       mOptions.mCreateHTMLCallback,
@@ -69,6 +85,12 @@ already_AddRefed<T> TrustedTypePolicy::CreateTrustedType(
   if (policyValue.IsVoid()) {
     policyValue = EmptyString();
   }
+
+  // Foxhound: A trusted type only wraps a string, so let taint flow through it.
+  // If the produced value is tainted (e.g. derived from a tainted input), record
+  // that it passed through the trusted type. This is a propagation node, not a
+  // source: untainted values stay untainted.
+  MarkTaintOperation(policyValue, TrustedTypeName<T>());
 
   RefPtr<T> trustedObject = new T(std::move(policyValue));
 

--- a/dom/security/trusted-types/TrustedTypeUtils.h
+++ b/dom/security/trusted-types/TrustedTypeUtils.h
@@ -215,6 +215,11 @@ GetConvertedScriptSourceForPreNavigationCheck(
       aResult.SetKnownLiveString(mData);                                    \
     }                                                                       \
                                                                             \
+    /* Foxhound: expose the taint of the wrapped string, using the same     \
+       shape as the `.taint` getter on primitive strings. */                \
+    void GetTaint(JSContext* aCx, JS::MutableHandle<JS::Value> aResult,     \
+                  ErrorResult& aError) const;                               \
+                                                                            \
     /* This is always unforged data, because it's only instantiated         \
        from the befriended `TrustedType*` classes and other trusted         \
        functions . */                                                       \
@@ -245,6 +250,13 @@ GetConvertedScriptSourceForPreNavigationCheck(
   bool _class::WrapObject(JSContext* aCx, JS::Handle<JSObject*> aGivenProto, \
                           JS::MutableHandle<JSObject*> aObject) {            \
     return _class##_Binding::Wrap(aCx, this, aGivenProto, aObject);          \
+  }                                                                          \
+                                                                            \
+  void _class::GetTaint(JSContext* aCx, JS::MutableHandle<JS::Value> aResult,\
+                        ErrorResult& aError) const {                         \
+    if (!JS_GetTaintAsObject(aCx, mData.Taint(), aResult)) {                 \
+      aError.NoteJSContextException(aCx);                                    \
+    }                                                                        \
   }
 
 #endif  // DOM_SECURITY_TRUSTED_TYPES_TRUSTEDTYPEUTILS_H_

--- a/dom/webidl/TrustedTypes.webidl
+++ b/dom/webidl/TrustedTypes.webidl
@@ -12,18 +12,24 @@
 interface TrustedHTML {
   stringifier;
   DOMString toJSON();
+  // Foxhound: taint of the wrapped string.
+  [Throws] readonly attribute any taint;
 };
 
 [Exposed=(Window,Worker), Pref="dom.security.trusted_types.enabled"]
 interface TrustedScript {
   stringifier;
   DOMString toJSON();
+  // Foxhound: taint of the wrapped string.
+  [Throws] readonly attribute any taint;
 };
 
 [Exposed=(Window,Worker), Pref="dom.security.trusted_types.enabled"]
 interface TrustedScriptURL {
   stringifier;
   USVString toJSON();
+  // Foxhound: taint of the wrapped string.
+  [Throws] readonly attribute any taint;
 };
 
 [Exposed=(Window,Worker), Pref="dom.security.trusted_types.enabled"]

--- a/js/src/builtin/String.cpp
+++ b/js/src/builtin/String.cpp
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <type_traits>
 
+#include "jsapi.h"
 #include "jsnum.h"
 #include "jstypes.h"
 
@@ -179,18 +180,13 @@ js::str_tainted(JSContext* cx, unsigned argc, Value* vp)
  *
  * This builds a JS representation of the taint information associated with a string.
  */
-static bool
-str_taint_getter(JSContext* cx, unsigned argc, Value* vp)
+JS_PUBLIC_API bool
+JS_GetTaintAsObject(JSContext* cx, const StringTaint& taint,
+                    JS::MutableHandleValue out)
 {
-  CallArgs args = CallArgsFromVp(argc, vp);
-
-  RootedString str(cx, ToString<CanGC>(cx, args.thisv()));
-  if (!str)
-    return false;
-
   // Wrap all taint ranges of the string.
   RootedValueVector ranges(cx);
-  for (const TaintRange& taint_range : str->taint()) {
+  for (const TaintRange& taint_range : taint) {
     RootedObject range(cx, JS_NewObject(cx, nullptr));
     if(!range)
       return false;
@@ -280,8 +276,20 @@ str_taint_getter(JSContext* cx, unsigned argc, Value* vp)
   if (!array)
     return false;
 
-  args.rval().setObject(*array);
+  out.setObject(*array);
   return true;
+}
+
+static bool
+str_taint_getter(JSContext* cx, unsigned argc, Value* vp)
+{
+  CallArgs args = CallArgsFromVp(argc, vp);
+
+  RootedString str(cx, ToString<CanGC>(cx, args.thisv()));
+  if (!str)
+    return false;
+
+  return JS_GetTaintAsObject(cx, str->taint(), args.rval());
 }
 
 static bool

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -1004,6 +1004,14 @@ JS_GetStringTaint(const JSLinearString* str);
 extern JS_PUBLIC_API void
 JS_SetStringTaint(JSContext* cx, JSString* str, const StringTaint& taint);
 
+// Foxhound: Build a JS object describing the given string taint. This mirrors
+// the structure returned by the `.taint` getter on primitive strings, so that
+// non-string carriers of tainted data (e.g. TrustedHTML) can expose their taint
+// through the same shape.
+extern JS_PUBLIC_API bool
+JS_GetTaintAsObject(JSContext* cx, const StringTaint& taint,
+                    JS::MutableHandleValue out);
+
 extern JS_PUBLIC_API void
 JS_SetTaint(JSContext* cx, JS::MutableHandle<JS::Value> aValue, const StringTaint& taint);
 

--- a/taint/test/mochitest/mochitest.ini
+++ b/taint/test/mochitest/mochitest.ini
@@ -64,3 +64,4 @@ scheme = https
 [test_toLowerCase.html]
 [test_normalize.html]
 [test_taint_source_arguments.html]
+[test_trusted_types.html]

--- a/taint/test/mochitest/test_trusted_types.html
+++ b/taint/test/mochitest/test_trusted_types.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Check that taint flows through Trusted Types and that the taint of the
+      wrapped string is exposed via the `taint` property on TrustedHTML,
+      TrustedScript and TrustedScriptURL.
+    </title>
+    <script src="/tests/SimpleTest/SimpleTest.js"></script>
+    <link rel="stylesheet" href="/tests/SimpleTest/test.css" />
+
+    <script type="text/javascript">
+      // `trustedTypes` is only exposed on a global that was created while
+      // `dom.security.trusted_types.enabled` was true. Flip the pref first, then
+      // run everything inside a freshly created (same-origin) iframe whose global
+      // therefore exposes the Trusted Types API.
+      let ttWin;
+      let ttDoc;
+      let policy;
+
+      // Every trusted type only wraps a string. The `taint` property must
+      // expose the very same shape as the `.taint` getter on a primitive
+      // string: an array of ranges, each with a `flow` of operation nodes.
+      function findOp(tainted, name) {
+        return tainted.taint[0].flow.find((o) => o.operation === name);
+      }
+
+      function findSource(tainted) {
+        return tainted.taint[0].flow.find((o) => o.source);
+      }
+
+      // Shared assertions for a trusted type minted from a tainted input.
+      // `opName` is the propagation node added by Foxhound when the value
+      // passes through the trusted type.
+      function checkTaintedTrustedType(trusted, opName) {
+        // Part 2: the taint property is exposed on the trusted type itself.
+        SimpleTest.ok(
+          trusted.taint !== undefined,
+          `${opName}.taint must be exposed`
+        );
+        SimpleTest.ok(
+          trusted.taint.length > 0,
+          `${opName}.taint must be non-empty for a tainted input`
+        );
+
+        // Part 1: taint flowed through the trusted type, keeping the original
+        // source and recording a propagation node for the trusted type.
+        const source = findSource(trusted);
+        SimpleTest.ok(source, `${opName} taint must retain its source`);
+        SimpleTest.is(
+          source.operation,
+          "TestSource",
+          `${opName} source operation must be preserved`
+        );
+        SimpleTest.ok(
+          findOp(trusted, opName),
+          `${opName} taint flow must contain a '${opName}' node`
+        );
+
+        // Stringifying the trusted type must keep the taint as well.
+        check_tainted(String(trusted));
+      }
+
+      add_task(async function setup() {
+        await SpecialPowers.pushPrefEnv({
+          set: [["dom.security.trusted_types.enabled", true]],
+        });
+
+        const iframe = document.createElement("iframe");
+        const loaded = new Promise((resolve) =>
+          iframe.addEventListener("load", resolve, { once: true })
+        );
+        iframe.srcdoc = "<!DOCTYPE html><title>tt</title>";
+        document.body.appendChild(iframe);
+        await loaded;
+
+        ttWin = iframe.contentWindow;
+        ttDoc = iframe.contentDocument;
+        SimpleTest.ok(
+          ttWin.trustedTypes,
+          "trustedTypes must be exposed in the iframe"
+        );
+
+        // A single policy providing identity callbacks for all three kinds of
+        // trusted type, so createXXX(input) simply wraps `input`. A policy name
+        // may only be created once, so it is shared across the tasks below.
+        policy = ttWin.trustedTypes.createPolicy("test-taint-policy", {
+          createHTML: (s) => s,
+          createScript: (s) => s,
+          createScriptURL: (s) => s,
+        });
+      });
+
+      add_task(async function test_createHTML() {
+        const input = String.tainted("<b>hello</b>", "TestSource");
+        const trusted = policy.createHTML(input);
+        checkTaintedTrustedType(trusted, "TrustedHTML");
+      });
+
+      add_task(async function test_createScript() {
+        const input = String.tainted("alert(1)", "TestSource");
+        const trusted = policy.createScript(input);
+        checkTaintedTrustedType(trusted, "TrustedScript");
+      });
+
+      add_task(async function test_createScriptURL() {
+        const input = String.tainted("https://example.com/x.js", "TestSource");
+        const trusted = policy.createScriptURL(input);
+        checkTaintedTrustedType(trusted, "TrustedScriptURL");
+      });
+
+      // Run `assign` (which feeds a trusted type into a Trusted Types sink) and
+      // resolve with the detail of the `__taintreport` CustomEvent that the
+      // sink fires. The report is dispatched synchronously from the sink; a
+      // srcdoc iframe reports on `parent.window` (its location is about:srcdoc),
+      // so we listen on both windows to be robust.
+      function captureSinkReport(assign) {
+        return new Promise((resolve, reject) => {
+          let done = false;
+          const onReport = (e) => {
+            if (done) {
+              return;
+            }
+            done = true;
+            window.removeEventListener("__taintreport", onReport, true);
+            ttWin.removeEventListener("__taintreport", onReport, true);
+            resolve(e.detail);
+          };
+          window.addEventListener("__taintreport", onReport, true);
+          ttWin.addEventListener("__taintreport", onReport, true);
+          try {
+            assign();
+          } catch (ex) {
+            reject(ex);
+          }
+        });
+      }
+
+      // A tainted value flowing through a trusted type into a Trusted Types sink
+      // must produce a report whose taint flow is the FULL chain: the original
+      // source, the trusted-type propagation node, and the sink itself.
+      async function checkSinkFullFlow({ input, mkTrusted, ttNode, sink, doSink }) {
+        const tainted = String.tainted(input, "TestSource");
+        const trusted = mkTrusted(tainted);
+        const detail = await captureSinkReport(() => doSink(trusted));
+
+        SimpleTest.is(detail.sink, sink, `Report sink must be '${sink}'`);
+        check_tainted(detail.str);
+
+        const ops = detail.str.taint[0].flow.map((o) => o.operation);
+        SimpleTest.ok(
+          detail.str.taint[0].flow.some((o) => o.source && o.operation === "TestSource"),
+          `[${sink}] flow must contain the source 'TestSource' (flow: ${ops})`
+        );
+        SimpleTest.ok(
+          ops.includes(ttNode),
+          `[${sink}] flow must contain the '${ttNode}' propagation node (flow: ${ops})`
+        );
+        SimpleTest.ok(
+          ops.includes(sink),
+          `[${sink}] flow must contain the sink node (flow: ${ops})`
+        );
+
+        // The chain must be ordered source -> trusted type -> sink.
+        const iSource = ops.lastIndexOf("TestSource");
+        const iTT = ops.indexOf(ttNode);
+        const iSink = ops.indexOf(sink);
+        SimpleTest.ok(
+          iSink < iTT && iTT < iSource,
+          `[${sink}] flow order must be sink..trusted-type..source (flow: ${ops})`
+        );
+      }
+
+      add_task(async function test_innerHTML_sink_full_flow() {
+        const target = ttDoc.createElement("div");
+        ttDoc.body.appendChild(target);
+        await checkSinkFullFlow({
+          input: "<b>xss</b>",
+          mkTrusted: (t) => policy.createHTML(t),
+          ttNode: "TrustedHTML",
+          sink: "innerHTML",
+          doSink: (trusted) => {
+            target.innerHTML = trusted;
+          },
+        });
+      });
+
+      add_task(async function test_outerHTML_sink_full_flow() {
+        const target = ttDoc.createElement("div");
+        ttDoc.body.appendChild(target);
+        await checkSinkFullFlow({
+          input: "<span>xss</span>",
+          mkTrusted: (t) => policy.createHTML(t),
+          ttNode: "TrustedHTML",
+          sink: "outerHTML",
+          doSink: (trusted) => {
+            target.outerHTML = trusted;
+          },
+        });
+      });
+
+      add_task(async function test_insertAdjacentHTML_sink_full_flow() {
+        const target = ttDoc.createElement("div");
+        ttDoc.body.appendChild(target);
+        await checkSinkFullFlow({
+          input: "<i>xss</i>",
+          mkTrusted: (t) => policy.createHTML(t),
+          ttNode: "TrustedHTML",
+          sink: "insertAdjacentHTML",
+          doSink: (trusted) => {
+            target.insertAdjacentHTML("beforeend", trusted);
+          },
+        });
+      });
+
+      // An untainted input must stay untainted: passing through a trusted type
+      // is a taint propagation, never a taint source.
+      add_task(async function test_untainted_input_stays_untainted() {
+        const html = policy.createHTML("<i>clean</i>");
+        const script = policy.createScript("noop()");
+        const url = policy.createScriptURL("https://example.com/clean.js");
+        SimpleTest.is(html.taint.length, 0, "TrustedHTML must be untainted");
+        SimpleTest.is(script.taint.length, 0, "TrustedScript must be untainted");
+        SimpleTest.is(url.taint.length, 0, "TrustedScriptURL must be untainted");
+        check_untainted(String(html));
+      });
+    </script>
+  </head>
+
+  <body></body>
+</html>


### PR DESCRIPTION
TrustedHTML/TrustedScript/TrustedScriptURL each just wrap an nsString, so:

- Taint flows through: TrustedTypePolicy::CreateTrustedType records a propagation node (MarkTaintOperation) named after the trusted type. This only extends existing taint, so untainted values stay untainted.

- Expose the wrapped string's taint via a new `[Throws] readonly attribute any taint;` on all three WebIDL interfaces. The getter reuses a new public JSAPI, JS_GetTaintAsObject(cx, const StringTaint&, MutableHandleValue), factored out of str_taint_getter so it returns the exact same shape as the `.taint` getter on primitive strings.

Also fix a general taint-loss bug in DOMString::SetKnownLiveString: the zero-copy string-buffer path copied taint from the shared StringBuffer, but a string's taint frequently lives on the string object itself (anything set via AssignTaint, which is how taint crosses from JS into an nsString). The UnownedStringBuffer state exposes mTaint (a copy, not the live buffer's taint) to JS, so prefer the source string's own taint when present. This is what lets String(trustedHTML) preserve taint, and covers other object-tainted strings returned through KnownLive binding getters.

Add taint/test/mochitest/test_trusted_types.html covering all three policies (taint-through, source preserved, propagation node, stringifier round-trip, and untainted-stays-untainted), plus sink-flow tests showing that when a tainted trusted type flows into a Trusted Types sink (innerHTML, outerHTML, insertAdjacentHTML) the reported __taintreport flow contains the full chain: source -> trusted-type propagation node -> sink, in that order.